### PR TITLE
changed mac primary symbolic link path

### DIFF
--- a/app/_posts/2013-01-09-sync-sublime-text-2-settings.md
+++ b/app/_posts/2013-01-09-sync-sublime-text-2-settings.md
@@ -21,7 +21,7 @@ ln -s ~/.config/sublime-text-2/Packages sublime-text-2-settings
 
 ```bash
 cd ~/Dropbox
-ln -s ~/'Library/Application Support/Sublime Text 2' sublime-text-2-settings
+ln -s ~/Library/Application Support/Sublime Text 2/Packages sublime-text-2-settings
 ```
 
 **Windows**


### PR DESCRIPTION
i run over your tutorial - thanks!
But i think there is a typo, when Mac OS X is your primary computer. At least i had to change the symbolic link, maybe you can verify that
